### PR TITLE
Update API base URL to ngrok domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Modern React-based frontend for exploring and querying open-source repository do
 
    Edit `.env` and configure:
    ```
-   VITE_API_BASE_URL=http://localhost:8000
+   VITE_API_BASE_URL=https://tianna-unretractive-ellen.ngrok-free.dev
    ```
 
 4. **Start the development server**

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: 'https://tianna-unretractive-ellen.ngrok-free.dev',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary
- replace the localhost API base URL with the ngrok domain in documentation and configuration

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912ce547f78832aa84189b90dbcefb5)