### PR TITLE
Add Netlify redirect for backend API proxy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,13 @@
   [build.environment]
     NODE_VERSION = "18"
 
+# Proxy API requests to the backend service
+[[redirects]]
+  from = "/api/*"
+  to = "https://tianna-unretractive-ellen.ngrok-free.dev/api/:splat"
+  status = 200
+  force = true
+
 # SPA routing - redirect all routes to index.html
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
## Summary
- add a Netlify redirect that proxies /api requests to the backend service
- ensure the API proxy runs before the single page app fallback rule

## Testing
- not run (not applicable)