### PR TITLE
Add Nafiz portfolio link to support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ MIT License - see LICENSE file for details
 For issues and questions:
 - GitHub Issues: https://github.com/RepoWise/frontend/issues
 - Documentation: https://github.com/RepoWise/frontend/wiki
+- Nafiz's Portfolio: https://nafiz43.github.io/portfolio/
 
 ## Related Projects
 


### PR DESCRIPTION
## Summary
- add a link to Nafiz's portfolio in the Support section of the README

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912dd659a24832a87cc84f58281d86e)