### PR TITLE
Add tooltips for matches and percentage context

### DIFF
--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1186,12 +1186,33 @@ function ChatInterface() {
                                             />
                                           </div>
                                           <span className={`text-xs font-medium ${colors.text}`}>
-                                            {relevanceScore}%
+                                            <span
+                                              className="tooltip-target"
+                                              aria-label="Relevance percentage"
+                                            >
+                                              {relevanceScore}%
+                                              <span className="tooltip">
+                                                The relevance score represented as a percentage. Higher values indicate
+                                                stronger alignment with your query.
+                                              </span>
+                                            </span>
                                           </span>
                                         </div>
                                         {source.matchCount && source.matchCount > 1 && (
                                           <span className="text-xs dark:text-emerald-400 text-emerald-600 font-medium">
-                                            ({source.matchCount} {source.matchCount === 1 ? 'match' : 'matches'})
+                                            (
+                                              {source.matchCount}{' '}
+                                              <span
+                                                className="tooltip-target"
+                                                aria-label="Matches tooltip"
+                                              >
+                                                {source.matchCount === 1 ? 'match' : 'matches'}
+                                                <span className="tooltip">
+                                                  The number of retrieved items (files, commits, metadata, or signals)
+                                                  that matched your query or context.
+                                                </span>
+                                              </span>
+                                            )
                                           </span>
                                         )}
                                         {source.file_type && (
@@ -1349,12 +1370,33 @@ function ChatInterface() {
                                         />
                                       </div>
                                       <span className={`text-xs font-medium ${colors.text}`}>
-                                        {relevanceScore}%
+                                        <span
+                                          className="tooltip-target"
+                                          aria-label="Relevance percentage"
+                                        >
+                                          {relevanceScore}%
+                                          <span className="tooltip">
+                                            The relevance score represented as a percentage. Higher values indicate
+                                            stronger alignment with your query.
+                                          </span>
+                                        </span>
                                       </span>
                                     </div>
                                     {source.matchCount && source.matchCount > 1 && (
                                       <span className="text-xs dark:text-emerald-400 text-emerald-600 font-medium">
-                                        ({source.matchCount} {source.matchCount === 1 ? 'match' : 'matches'})
+                                        (
+                                          {source.matchCount}{' '}
+                                          <span
+                                            className="tooltip-target"
+                                            aria-label="Matches tooltip"
+                                          >
+                                            {source.matchCount === 1 ? 'match' : 'matches'}
+                                            <span className="tooltip">
+                                              The number of retrieved items (files, commits, metadata, or signals) that
+                                              matched your query or context.
+                                            </span>
+                                          </span>
+                                        )
                                       </span>
                                     )}
                                     {source.file_type && (

--- a/src/index.css
+++ b/src/index.css
@@ -84,3 +84,34 @@
   color: #dc2626;
   font-weight: 600;
 }
+
+.tooltip-target {
+  position: relative;
+  cursor: help;
+  display: inline-flex;
+  align-items: center;
+}
+
+.tooltip {
+  visibility: hidden;
+  opacity: 0;
+  position: absolute;
+  background: #1f2937;
+  color: white;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  width: max-content;
+  max-width: 240px;
+  top: 120%;
+  left: 0;
+  z-index: 20;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.tooltip-target:hover .tooltip,
+.tooltip-target:focus .tooltip,
+.tooltip-target:focus-visible .tooltip {
+  visibility: visible;
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- add reusable tooltip styles that match RepoWise visual language
- wrap the relevance percentage display with a tooltip explaining how to interpret the score
- wrap the match count label with a tooltip that defines what constitutes a match in RepoWise

## Testing
- npm run build *(fails: [vite]: Rollup failed to resolve import "rehype-raw" from "src/components/ChatInterface.jsx" – existing issue in the project)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d2bddff08832a978874e655d9c78c)