### PR TITLE
Remove ExternalLink icon on Sources and also removed 5 secs timer for Success message

### DIFF
--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1125,7 +1125,7 @@ function ChatInterface() {
                                     className="flex items-start space-x-4 p-4
                                              dark:bg-gray-900/50 dark:hover:bg-gray-800/50 dark:border-gray-800 dark:hover:border-gray-700
                                              bg-white hover:bg-gray-50 border-2 border-gray-200 hover:border-gray-300
-                                             rounded-xl transition-all group cursor-pointer"
+                                             rounded-xl transition-all"
                                   >
                                     <div className={`flex-shrink-0 p-2 ${colors.bg} rounded-lg border ${colors.border}`}>
                                       {getSourceIcon(source.file_type)}


### PR DESCRIPTION
The Sources link is not needed, and the icon is misleading, so removed it. 
The 5 sec timer for Success message for Add repo functionality can be mislieading in situations when a user adds a repo and then moves to some other website or performs some other task and then returns back (after atleast 5 secs) to RepoWise website, then the user would have missed the Success message for Add Repo and would not know that the Repo was added succesfully. So, let the message persist on screen and let the user manually close the message, to ensure capturing the event that user has seen the Success message for Add Repo and knows what next to do in the tool. 