### PR TITLE
Display user count from API in footer

### DIFF
--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -143,6 +143,14 @@ function ChatInterface() {
     refetchInterval: 30000,
   })
 
+  // Fetch user count for dashboard footer
+  const { data: usersData } = useQuery({
+    queryKey: ['users'],
+    queryFn: () => api.listUsers().then((res) => res.data),
+    enabled: isAuthenticated,
+    refetchInterval: 30000,
+  })
+
   // Record a view when the dashboard is used
   useEffect(() => {
     const trackView = async () => {
@@ -160,6 +168,13 @@ function ChatInterface() {
   const availableProjects = projectsData?.data?.projects || []
 
   const viewCount = viewCountData?.view_count ?? viewCountData?.count
+  const userCount = Array.isArray(usersData?.users)
+    ? usersData.users.length
+    : Array.isArray(usersData)
+      ? usersData.length
+      : Array.isArray(usersData?.data)
+        ? usersData.data.length
+        : null
 
   // Add repository and index mutation
   const addRepoMutation = useMutation({
@@ -1746,9 +1761,11 @@ function ChatInterface() {
               repowise.github.io
             </a>
           </p>
-          <p className="text-gray-500 dark:text-gray-500">
-            RepoWise Views: {viewCount ?? '—'}
-          </p>
+          <div className="flex flex-wrap items-center gap-4 text-gray-500 dark:text-gray-500">
+            <span>RepoWise Views: {viewCount ?? '—'}</span>
+            <span className="h-4 w-px bg-gray-300 dark:bg-gray-600" aria-hidden="true"></span>
+            <span>RepoWise Users: {userCount ?? '—'}</span>
+          </div>
         </div>
       </footer>
       

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -94,6 +94,9 @@ export const api = {
   // View tracking
   recordView: () => apiClient.post('/record_view'),
   getViewCount: () => apiClient.get('/view_count'),
+
+  // Users
+  listUsers: () => apiClient.get('/auth/users'),
 };
 
 export default api;


### PR DESCRIPTION
## Summary
- add API client helper for fetching registered users
- query user list in the chat interface to derive and display total count
- show RepoWise user count beside the existing views metric in the footer

## Testing
- not run (not requested)