### PR TITLE
Use simple user count endpoint

### DIFF
--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -144,9 +144,9 @@ function ChatInterface() {
   })
 
   // Fetch user count for dashboard footer
-  const { data: usersData } = useQuery({
-    queryKey: ['users'],
-    queryFn: () => api.listUsers().then((res) => res.data),
+  const { data: userCountData } = useQuery({
+    queryKey: ['userCount'],
+    queryFn: () => api.getUserCount().then((res) => res.data),
     enabled: isAuthenticated,
     refetchInterval: 30000,
   })
@@ -168,13 +168,7 @@ function ChatInterface() {
   const availableProjects = projectsData?.data?.projects || []
 
   const viewCount = viewCountData?.view_count ?? viewCountData?.count
-  const userCount = Array.isArray(usersData?.users)
-    ? usersData.users.length
-    : Array.isArray(usersData)
-      ? usersData.length
-      : Array.isArray(usersData?.data)
-        ? usersData.data.length
-        : null
+  const userCount = userCountData?.count ?? userCountData?.user_count ?? null
 
   // Add repository and index mutation
   const addRepoMutation = useMutation({

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -96,7 +96,7 @@ export const api = {
   getViewCount: () => apiClient.get('/view_count'),
 
   // Users
-  listUsers: () => apiClient.get('/auth/users'),
+  getUserCount: () => apiClient.get('/auth/users/count'),
 };
 
 export default api;


### PR DESCRIPTION
## Summary
- update the API client to call the new /auth/users/count endpoint using the env-configured base URL
- simplify the dashboard footer query to read the returned user count directly

## Testing
- npm run build