### PR TITLE
Fetch user count without auth gate

### DIFF
--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -147,7 +147,6 @@ function ChatInterface() {
   const { data: userCountData } = useQuery({
     queryKey: ['userCount'],
     queryFn: () => api.getUserCount().then((res) => res.data),
-    enabled: isAuthenticated,
     refetchInterval: 30000,
   })
 


### PR DESCRIPTION
## Summary
- fetch the user count without gating the query behind authentication so it shows on the dashboard
- keep periodic refresh of user count consistent with other dashboard metrics

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920074c09e4832a8b628c8d708bd655)