### PR TITLE
Enhance RepoWise response formatting

### DIFF
--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -38,6 +38,7 @@ import { ThemeToggle } from './ThemeToggle'
 import { useAuth } from '../contexts/AuthContext'
 import { highlightEntities } from '../lib/highlightEntities'
 import { highlightSustainabilityTerms } from '../lib/sustainabilityHighlights'
+import { formatResponseLayout } from '../lib/responseFormatter'
 
 const EXAMPLE_REPOSITORIES = [
   {
@@ -297,7 +298,8 @@ function ChatInterface() {
       const uniqueSources = Object.values(sourcesByPath)
 
       const rawResponse = data?.data?.response || 'No response received'
-      const entityHighlighted = highlightEntities(rawResponse)
+      const structuredResponse = formatResponseLayout(rawResponse)
+      const entityHighlighted = highlightEntities(structuredResponse)
       const styledResponse = highlightSustainabilityTerms(entityHighlighted)
 
       setMessages(prev => [...prev, {

--- a/src/index.css
+++ b/src/index.css
@@ -116,6 +116,100 @@
   opacity: 1;
 }
 
+.prose p,
+.prose li {
+  line-height: 1.8;
+}
+
+.prose h2,
+.prose h3,
+.prose h4 {
+  margin-top: 1.75rem;
+  scroll-margin-top: 5rem;
+}
+
+.prose h2 {
+  margin-bottom: 0.65rem;
+}
+
+.prose h3,
+.prose h4 {
+  margin-bottom: 0.5rem;
+}
+
+.prose pre {
+  position: relative;
+  padding: 1rem 1.25rem;
+  border-radius: 0.9rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  border: 1px solid rgba(226, 232, 240, 0.1);
+}
+
+.prose pre code {
+  background: transparent;
+}
+
+.prose details {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  background: rgba(15, 23, 42, 0.25);
+}
+
+.prose details summary {
+  cursor: pointer;
+  font-weight: 600;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.prose details summary::-webkit-details-marker {
+  display: none;
+}
+
+.prose details[open] {
+  margin-bottom: 1rem;
+}
+
+.rw-link-block {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.85rem;
+  padding: 0.75rem 0.9rem;
+  background: rgba(240, 253, 250, 0.4);
+  margin: 0.75rem 0;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.dark .rw-link-block {
+  background: rgba(16, 185, 129, 0.12);
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
+.rw-link-title {
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.dark .rw-link-title {
+  color: #e2e8f0;
+}
+
+.rw-link-url {
+  font-family: ui-monospace, SFMono-Regular, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+  font-size: 0.95rem;
+  color: #0369a1;
+  word-break: break-all;
+}
+
+.dark .rw-link-url {
+  color: #7dd3fc;
+}
+
 /* One-time shimmer effect for Change Repo button */
 @keyframes shimmer {
   0% {

--- a/src/lib/responseFormatter.js
+++ b/src/lib/responseFormatter.js
@@ -1,0 +1,151 @@
+const CODE_FENCE_REGEX = /```[\s\S]*?```/g
+
+const SECTION_HEADINGS = [
+  'Summary',
+  'Overview',
+  'Highlights',
+  'What changed',
+  'Steps',
+  'How to run',
+  'Commands',
+  'Testing',
+  'Requirements',
+  'Notes',
+  'Details',
+  'Resources',
+  'Links',
+  'Follow-up',
+  'Troubleshooting'
+]
+
+const COMMAND_KEYWORDS = [
+  'npm',
+  'yarn',
+  'pnpm',
+  'pip',
+  'pip3',
+  'python',
+  'python3',
+  'git',
+  'docker',
+  'make',
+  'npx',
+  'act',
+  'uvicorn',
+  'cargo',
+  'bundle',
+  'rails'
+]
+
+const applyOutsideCode = (text, pattern, replacer) => {
+  if (!text) return text
+
+  let lastIndex = 0
+  const parts = []
+
+  text.replace(CODE_FENCE_REGEX, (match, offset) => {
+    const preceding = text.slice(lastIndex, offset)
+    if (preceding) {
+      parts.push(preceding.replace(pattern, replacer))
+    }
+    parts.push(match)
+    lastIndex = offset + match.length
+    return match
+  })
+
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex).replace(pattern, replacer))
+  }
+
+  if (parts.length === 0) {
+    return text.replace(pattern, replacer)
+  }
+
+  return parts.join('')
+}
+
+const formatSectionHeadings = (text) => {
+  const pattern = new RegExp(`(^|\n)(${SECTION_HEADINGS.join('|')}):`, 'gi')
+  return applyOutsideCode(text, pattern, (_match, prefix, title) => `${prefix}### ${title}\n`)
+}
+
+const formatLinkBlocks = (text) => {
+  const markdownLinkPattern = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/gi
+  return applyOutsideCode(
+    text,
+    markdownLinkPattern,
+    (_match, label, url) =>
+      `\n<div class="rw-link-block">\n  <div class="rw-link-title">📄 ${label}</div>\n  <div class="rw-link-url">${url}</div>\n</div>\n`
+  )
+}
+
+const formatCommandBlocks = (text) => {
+  const keywords = COMMAND_KEYWORDS.join('|')
+  const commandPattern = new RegExp(`(^|\n)(?:-\s+)?(?:\$\s*)?((${keywords})[^\n]*)`, 'gmi')
+
+  return applyOutsideCode(text, commandPattern, (_match, prefix, command) => {
+    const cleaned = command.replace(/^\$\s*/, '').trim()
+    return `${prefix}\n\n\`\`\`bash\n${cleaned}\n\`\`\`\n\n`
+  })
+}
+
+const formatInlineCode = (text) => {
+  const filePattern = /\b([\w./-]+\.(?:md|markdown|mdx|py|pyi|js|jsx|ts|tsx|cjs|mjs|json|yaml|yml|toml|ini|conf|config|lock|txt|csv|html|css|scss|less|sass|rb|go|rs|java|kt|c|h|hpp|cpp|sh|ps1|bat|sql|mdoc|rst|vue|svelte))\b/gi
+
+  return applyOutsideCode(text, filePattern, (match) => `\`${match}\``)
+}
+
+const formatDetailsBlocks = (text) => {
+  const detailsPattern = /(^|\n)(More details|Additional context):\s*\n+/gi
+  return applyOutsideCode(text, detailsPattern, (_match, prefix, label) => `${prefix}<details>\n<summary>${label}</summary>\n\n`)
+}
+
+const closeDetailsBlocks = (text) => {
+  if (!text.includes('<details>')) return text
+  const lines = text.split('\n')
+  const stack = []
+  const result = []
+
+  lines.forEach((line) => {
+    const trimmed = line.trim()
+    if (trimmed.startsWith('<details')) {
+      stack.push(true)
+      result.push(line)
+      return
+    }
+
+    if (stack.length && /^###\s+/i.test(trimmed)) {
+      result.push('</details>\n')
+      stack.pop()
+    }
+
+    result.push(line)
+  })
+
+  while (stack.length) {
+    result.push('</details>')
+    stack.pop()
+  }
+
+  return result.join('\n')
+}
+
+const normalizeSpacing = (text) =>
+  text
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/(### [^\n]+)\n(?!\n)/g, '$1\n\n')
+    .trim()
+
+export const formatResponseLayout = (text) => {
+  if (!text || typeof text !== 'string') return text
+
+  const withHeadings = formatSectionHeadings(text)
+  const withCommands = formatCommandBlocks(withHeadings)
+  const withLinks = formatLinkBlocks(withCommands)
+  const withInlineCode = formatInlineCode(withLinks)
+  const withDetails = formatDetailsBlocks(withInlineCode)
+  const closedDetails = closeDetailsBlocks(withDetails)
+
+  return normalizeSpacing(closedDetails)
+}
+


### PR DESCRIPTION
## Summary
- add a response layout formatter to structure RepoWise answers with headings, code fences, and rich link blocks
- highlight commands, files, and collapsible detail sections before applying entity styling for more readable answers
- refresh markdown styling for better spacing, link blocks, and expandable sections in the chat interface

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693095ae032c832a9073d275f043fd02)