### PR TITLE
Add Playwright E2E tests, backend health check script, and CI workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,50 @@
+name: Playwright E2E
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    env:
+      E2E_API_BASE_URL: ${{ vars.E2E_API_BASE_URL || secrets.E2E_API_BASE_URL }}
+      E2E_REPO_URL: ${{ vars.E2E_REPO_URL || secrets.E2E_REPO_URL }}
+      E2E_QUESTION: ${{ vars.E2E_QUESTION || secrets.E2E_QUESTION }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Check backend health
+        run: node scripts/check-backend-health.mjs
+
+      - name: Run Playwright tests
+        env:
+          E2E_API_BASE_URL: ${{ env.E2E_API_BASE_URL }}
+          E2E_REPO_URL: ${{ env.E2E_REPO_URL }}
+          E2E_QUESTION: ${{ env.E2E_QUESTION }}
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules/
 *.test.js
 *.spec.js
 !src/**/*.test.js
+!tests/e2e/**/*.spec.js
 
 # Logs
 logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.1",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@vitejs/plugin-react": "^4.2.1",
@@ -1033,6 +1034,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
+      "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -7413,6 +7430,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "test": "vitest"
+    "test": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-scroll-area": "^1.0.5",
@@ -35,6 +36,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.1",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^4.2.1",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,28 @@
+import { defineConfig } from '@playwright/test'
+
+const baseURL = process.env.E2E_BASE_URL || 'http://localhost:4173'
+const apiBaseEnv = process.env.E2E_API_BASE_URL || process.env.VITE_API_BASE_URL || 'http://localhost:8000'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 180_000,
+  expect: {
+    timeout: 30_000,
+  },
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : [['list']],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  webServer: {
+    command: 'npm run dev -- --host 0.0.0.0 --port 4173',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      VITE_API_BASE_URL: apiBaseEnv,
+    },
+  },
+})

--- a/scripts/check-backend-health.mjs
+++ b/scripts/check-backend-health.mjs
@@ -1,0 +1,53 @@
+const apiBaseEnv = process.env.E2E_API_BASE_URL || process.env.VITE_API_BASE_URL || 'http://localhost:8000'
+const apiBase = apiBaseEnv.replace(/\/(api)\/?$/, '')
+const healthUrl = new URL('/api/health', apiBase).toString()
+
+const summaryPath = process.env.GITHUB_STEP_SUMMARY
+
+const writeSummary = async (lines) => {
+  if (!summaryPath) return
+  await import('node:fs/promises').then(({ appendFile }) =>
+    appendFile(summaryPath, `${lines.join('\n')}\n`, 'utf8')
+  )
+}
+
+const abortController = new AbortController()
+const timeout = setTimeout(() => abortController.abort(), 10_000)
+
+let ok = false
+let errorMessage = ''
+
+try {
+  const response = await fetch(healthUrl, { signal: abortController.signal })
+  ok = response.ok
+  if (!ok) {
+    errorMessage = `Backend health check failed with status ${response.status}.`
+  }
+} catch (error) {
+  errorMessage = `Backend health check failed: ${error.message}`
+}
+
+clearTimeout(timeout)
+
+if (!ok) {
+  const message = `${errorMessage} URL: ${healthUrl}`
+  console.error(message)
+  console.log(`::error::${message}`)
+  await writeSummary([
+    '## RepoWise E2E Backend Health Check',
+    '',
+    `- Status: ❌ Down`,
+    `- URL: ${healthUrl}`,
+    `- Error: ${errorMessage}`,
+  ])
+  process.exit(1)
+}
+
+await writeSummary([
+  '## RepoWise E2E Backend Health Check',
+  '',
+  `- Status: ✅ Up`,
+  `- URL: ${healthUrl}`,
+])
+
+console.log(`Backend health check passed: ${healthUrl}`)

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1022,7 +1022,7 @@ function ChatInterface() {
                 )}
 
                 {msg.type === 'assistant' && (
-                  <div className="space-y-6">
+                  <div className="space-y-6" data-testid="assistant-message">
                     {/* Tabs */}
                     <div className="flex items-center space-x-1 border-b dark:border-gray-800 border-gray-200">
                       {['answer', 'sources'].map((tab) => (
@@ -1050,7 +1050,7 @@ function ChatInterface() {
                     {(activeTabs[idx] || 'answer') === 'answer' && (
                       <div className="space-y-6">
                         {/* Main Answer */}
-                        <div className="prose dark:prose-invert prose-lg max-w-none">
+                        <div className="prose dark:prose-invert prose-lg max-w-none" data-testid="assistant-answer">
                           <ReactMarkdown
                             remarkPlugins={[remarkGfm]}
                             rehypePlugins={[rehypeRaw, rehypeHighlight]}
@@ -1716,6 +1716,7 @@ function ChatInterface() {
                   }}
                   placeholder="Ask about governance, commits, issues, or contribution guidelines..."
                   disabled={!selectedProject || queryMutation.isPending || editingMessageId !== null}
+                  data-testid="chat-query-input"
                   rows={1}
                   className="w-full bg-transparent border-0 focus:outline-none resize-none
                            dark:text-gray-100 dark:placeholder-gray-500
@@ -1727,6 +1728,7 @@ function ChatInterface() {
               <button
                 type="submit"
                 disabled={!query.trim() || !selectedProject || queryMutation.isPending || editingMessageId !== null}
+                data-testid="chat-send-button"
                 className="flex-shrink-0 p-3 bg-gradient-to-br from-emerald-500 to-teal-600 hover:from-emerald-600 hover:to-teal-700 text-white rounded-xl transition-all disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-emerald-500/20 hover:shadow-emerald-500/30 hover:-translate-y-0.5"
               >
                 <Send className="w-5 h-5" />

--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -170,6 +170,7 @@ export function LandingHero({ onAddRepository, isLoading, indexingStatus, user, 
               value={inputValue}
               onChange={handleInputChange}
               onFocus={handleInputFocus}
+              data-testid="repo-url-input"
               placeholder="microsoft/codetour"
               disabled={isLoading}
               className="relative w-full px-6 py-5 text-lg rounded-2xl border-2
@@ -252,6 +253,7 @@ export function LandingHero({ onAddRepository, isLoading, indexingStatus, user, 
           transition={{ duration: 0.5, delay: 0.5 }}
           onClick={handleSubmit}
           disabled={!inputValue.trim() || isLoading}
+          data-testid="repo-add-button"
           className="px-12 py-4
                    bg-gradient-to-br from-emerald-500 to-teal-600
                    hover:from-emerald-600 hover:to-teal-700
@@ -274,6 +276,8 @@ export function LandingHero({ onAddRepository, isLoading, indexingStatus, user, 
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}
               className="mt-6"
+              data-testid="repo-indexing-status"
+              data-status={indexingStatus.status}
             >
               {indexingStatus.status === 'success' && (
                 <div className="flex items-center justify-center gap-3 text-emerald-600 dark:text-emerald-400">

--- a/tests/e2e/repowise.spec.js
+++ b/tests/e2e/repowise.spec.js
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test'
+
+const getApiBaseUrl = () => {
+  const raw = process.env.E2E_API_BASE_URL || process.env.VITE_API_BASE_URL || 'http://localhost:8000'
+  return raw.replace(/\/(api)\/?$/, '')
+}
+
+const getHealthUrl = () => {
+  const apiBase = getApiBaseUrl()
+  return new URL('/api/health', apiBase).toString()
+}
+
+test.describe('RepoWise E2E', () => {
+  test('backend health check', async ({ request }) => {
+    const response = await request.get(getHealthUrl(), { timeout: 10_000 })
+    expect(response.ok(), `Backend health check failed at ${getHealthUrl()}`).toBeTruthy()
+  })
+
+  test('add repository and ask a question', async ({ page }) => {
+    const repoUrl = process.env.E2E_REPO_URL || 'https://github.com/microsoft/TypeScript'
+    const question = process.env.E2E_QUESTION || 'What license does this project use?'
+
+    await page.goto('/')
+
+    await page.getByTestId('repo-url-input').fill(repoUrl)
+    await page.getByTestId('repo-add-button').click()
+
+    const status = page.getByTestId('repo-indexing-status')
+    await expect(status).toHaveAttribute('data-status', 'success', { timeout: 120_000 })
+
+    await expect(page.getByTestId('chat-query-input')).toBeVisible({ timeout: 30_000 })
+    await page.getByTestId('chat-query-input').fill(question)
+    await page.getByTestId('chat-send-button').click()
+
+    const latestAnswer = page.getByTestId('assistant-answer').last()
+    await expect(latestAnswer).toBeVisible({ timeout: 120_000 })
+    await expect(latestAnswer).toContainText(/\S+/, { timeout: 120_000 })
+  })
+})


### PR DESCRIPTION
### Motivation
- Provide automated end-to-end coverage for RepoWise that verifies repository ingestion, query responses, and backend availability. 
- Detect and notify in CI when the backend is down before running E2E tests to avoid noisy failures.

### Description
- Add Playwright configuration at `playwright.config.js` and an E2E spec at `tests/e2e/repowise.spec.js` that checks backend health, adds a repo through the UI, and asks a question.
- Add a backend health check script `scripts/check-backend-health.mjs` that fails gracefully, writes to the GitHub step summary, and emits an error if the backend is unreachable.
- Add a GitHub Actions workflow `.github/workflows/playwright.yml` to run the health check and Playwright tests (`npm run test:e2e`) on pushes, PRs, scheduled runs, and manual dispatch.
- Add stable testing selectors (`data-testid`) to `src/components/LandingHero.jsx` and `src/components/ChatInterface.jsx` for `repo-url-input`, `repo-add-button`, `repo-indexing-status`, `chat-query-input`, and `chat-send-button` and allow `tests/e2e/**/*.spec.js` in `.gitignore`.
- Add `@playwright/test` as a dev dependency and an npm script `test:e2e` to run `playwright test` in `package.json`.

### Testing
- Installed Playwright locally via `npm install -D @playwright/test`, which completed successfully on the change branch. 
- No automated test suites were executed locally as part of this change. 
- CI is configured to run `node scripts/check-backend-health.mjs` followed by `npm run test:e2e` (Playwright), and the workflow will upload the Playwright report on completion.